### PR TITLE
Adds CircleCI build/test to redis-namespace fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2.1
+jobs:
+  test:
+    docker:
+      - image: circleci/python:3.5.9
+      - image: circleci/redis:5.0.0
+    steps:
+      - checkout
+      - run: python setup.py install
+      - run: pip install pytest mock
+      - run: py.test
+workflows:
+  test:
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 jobs:
-  test:
+  install-and-test:
     docker:
       - image: circleci/python:3.5.9
       - image: circleci/redis:5.0.0
@@ -12,4 +12,4 @@ jobs:
 workflows:
   test:
     jobs:
-      - test
+      - install-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: circleci/redis:5.0.0
     steps:
       - checkout
-      - run: python setup.py install
+      - run: sudo python setup.py install
       - run: pip install pytest mock
       - run: py.test
 workflows:


### PR DESCRIPTION
Adds a CircleCI config file that mirrors the Travis config to build and test the package. It uses Python 3.5.9, which is where we're at with Celery. Otherwise follows https://github.com/bevy/redis-namespace/blob/master/.travis.yml for steps.